### PR TITLE
Phob/sc-35/integrate-configuration-from-db

### DIFF
--- a/src/PlexLocalScan.Api/Loader/DatabaseSettingsLoader.cs
+++ b/src/PlexLocalScan.Api/Loader/DatabaseSettingsLoader.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.EntityFrameworkCore;
+using PlexLocalScan.Data.Data;
+
+namespace PlexLocalScan.Api.Loader;
+
+internal sealed class DatabaseSettingsLoader(PlexScanContext dbContext)
+{
+    public async Task<PlexDbOptions> LoadPlexOptionsAsync() =>
+        await dbContext.PlexDbOptions
+            .Include(po => po.FolderMappings)
+            .FirstOrDefaultAsync() ?? new PlexDbOptions();
+
+    public async Task<TmDbDbOptions> LoadTmDbOptionsAsync() => await dbContext.TmDbDbOptions.FirstOrDefaultAsync() ?? new TmDbDbOptions();
+
+    public async Task<MediaDetectionDbOptions> LoadMediaDetectionOptionsAsync()
+    {
+        MediaDetectionDbOptions? options = await dbContext.MediaDetectionDbOptions.FirstOrDefaultAsync();
+        return options ?? new MediaDetectionDbOptions { CacheDurationSeconds = (int)TimeSpan.FromHours(24).TotalSeconds };
+    }
+}

--- a/src/PlexLocalScan.Data/Data/FolderMappingDbOptions.cs
+++ b/src/PlexLocalScan.Data/Data/FolderMappingDbOptions.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using PlexLocalScan.Core.Tables;
+
+namespace PlexLocalScan.Data.Data;
+
+public class FolderMappingDbOptions
+{
+    private const string DefaultFolderPath = "";
+    [Key]
+    public int Id { get; set; }
+
+    [ForeignKey("PlexOptions")]
+    public int LinkedPlexOptionsId { get; set; }
+
+    [MaxLength(255)]
+    public string SourceFolder { get; set; } = DefaultFolderPath;
+
+    [MaxLength(255)]
+    public string DestinationFolder { get; set; } = DefaultFolderPath;
+
+    public MediaType MediaType { get; set; }
+
+    public PlexDbOptions? PlexOptions { get; init; }
+}

--- a/src/PlexLocalScan.Data/Data/MediaDetectionDbOptions.cs
+++ b/src/PlexLocalScan.Data/Data/MediaDetectionDbOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace PlexLocalScan.Data.Data;
+
+public class MediaDetectionDbOptions
+{
+    public int Id { get; set; }
+    public TimeSpan CacheDuration => TimeSpan.FromSeconds(CacheDurationSeconds);
+    public int CacheDurationSeconds { get; set; }
+}

--- a/src/PlexLocalScan.Data/Data/PlexDbOptions.cs
+++ b/src/PlexLocalScan.Data/Data/PlexDbOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace PlexLocalScan.Data.Data;
+
+public class PlexDbOptions
+{
+    public int Id { get; set; }
+    public string Host { get; set; } = string.Empty;
+    public int Port { get; set; }
+    public string PlexToken { get; set; } = string.Empty;
+    public int PollingInterval { get; set; }
+    public int ProcessNewFolderDelay { get; set; }
+    public ICollection<FolderMappingDbOptions> FolderMappings { get; } = [];
+}

--- a/src/PlexLocalScan.Data/Data/PlexScanContext.cs
+++ b/src/PlexLocalScan.Data/Data/PlexScanContext.cs
@@ -3,15 +3,45 @@ using PlexLocalScan.Core.Tables;
 
 namespace PlexLocalScan.Data.Data;
 
-public sealed class PlexScanContext : DbContext
+public sealed class PlexScanContext(DbContextOptions<PlexScanContext> options) : DbContext(options)
 {
-    public DbSet<ScannedFile> ScannedFiles { get; set; }
-
-    public PlexScanContext(DbContextOptions<PlexScanContext> options)
-        : base(options) => ScannedFiles = Set<ScannedFile>();
+    public DbSet<ScannedFile> ScannedFiles { get; set; } = null!;
+    public DbSet<PlexDbOptions> PlexDbOptions { get; set; } = null!;
+    public DbSet<FolderMappingDbOptions> FolderDbMappings { get; set; } = null!;
+    public DbSet<TmDbDbOptions> TmDbDbOptions { get; set; } = null!;
+    public DbSet<MediaDetectionDbOptions> MediaDetectionDbOptions { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        base.OnModelCreating(modelBuilder);
+        
+        
+        // PlexOptions configuration
+        modelBuilder.Entity<PlexDbOptions>()
+            .HasKey(po => po.Id);
+
+        modelBuilder.Entity<PlexDbOptions>()
+            .HasMany(po => po.FolderMappings)
+            .WithOne(fm => fm.PlexOptions)
+            .HasForeignKey(fm => fm.LinkedPlexOptionsId);
+
+        // FolderMappingOptions configuration
+        modelBuilder.Entity<FolderMappingDbOptions>()
+            .HasKey(fm => fm.Id);
+
+        modelBuilder.Entity<FolderMappingDbOptions>()
+            .Property(fm => fm.MediaType)
+            .HasConversion<string>();
+
+        // TmDbOptions configuration
+        modelBuilder.Entity<TmDbDbOptions>()
+            .HasKey(tm => tm.Id);
+
+        // MediaDetectionOptions configuration
+        modelBuilder.Entity<MediaDetectionDbOptions>()
+            .HasKey(md => md.Id);
+        
+        // ScannedFiles
         modelBuilder.Entity<ScannedFile>()
             .HasIndex(f => f.SourceFile);
 

--- a/src/PlexLocalScan.Data/Data/TmDbDbOptions.cs
+++ b/src/PlexLocalScan.Data/Data/TmDbDbOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace PlexLocalScan.Data.Data;
+
+public class TmDbDbOptions
+{
+    public int Id { get; set; }
+    public string ApiKey { get; set; } = string.Empty;
+}

--- a/src/PlexLocalScan.Data/Migrations/20250115195408_AddPlexOptionsAndRelatedTables.Designer.cs
+++ b/src/PlexLocalScan.Data/Migrations/20250115195408_AddPlexOptionsAndRelatedTables.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PlexLocalScan.Data.Data;
 
@@ -10,9 +11,11 @@ using PlexLocalScan.Data.Data;
 namespace PlexLocalScan.Data.Migrations
 {
     [DbContext(typeof(PlexScanContext))]
-    partial class PlexScanContextModelSnapshot : ModelSnapshot
+    [Migration("20250115195408_AddPlexOptionsAndRelatedTables")]
+    partial class AddPlexOptionsAndRelatedTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.0");

--- a/src/PlexLocalScan.Data/Migrations/20250115195408_AddPlexOptionsAndRelatedTables.cs
+++ b/src/PlexLocalScan.Data/Migrations/20250115195408_AddPlexOptionsAndRelatedTables.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PlexLocalScan.Data.Migrations;
+
+/// <inheritdoc />
+public partial class AddPlexOptionsAndRelatedTables : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "MediaDetectionDbOptions",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "INTEGER", nullable: false)
+                    .Annotation("Sqlite:Autoincrement", true),
+                CacheDurationSeconds = table.Column<int>(type: "INTEGER", nullable: false)
+            },
+            constraints: table => table.PrimaryKey("PK_MediaDetectionDbOptions", x => x.Id));
+
+        migrationBuilder.CreateTable(
+            name: "PlexDbOptions",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "INTEGER", nullable: false)
+                    .Annotation("Sqlite:Autoincrement", true),
+                Host = table.Column<string>(type: "TEXT", nullable: false),
+                Port = table.Column<int>(type: "INTEGER", nullable: false),
+                PlexToken = table.Column<string>(type: "TEXT", nullable: false),
+                PollingInterval = table.Column<int>(type: "INTEGER", nullable: false),
+                ProcessNewFolderDelay = table.Column<int>(type: "INTEGER", nullable: false)
+            },
+            constraints: table => table.PrimaryKey("PK_PlexDbOptions", x => x.Id));
+
+        migrationBuilder.CreateTable(
+            name: "TmDbDbOptions",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "INTEGER", nullable: false)
+                    .Annotation("Sqlite:Autoincrement", true),
+                ApiKey = table.Column<string>(type: "TEXT", nullable: false)
+            },
+            constraints: table => table.PrimaryKey("PK_TmDbDbOptions", x => x.Id));
+
+        migrationBuilder.CreateTable(
+            name: "FolderDbMappings",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "INTEGER", nullable: false)
+                    .Annotation("Sqlite:Autoincrement", true),
+                LinkedPlexOptionsId = table.Column<int>(type: "INTEGER", nullable: false),
+                SourceFolder = table.Column<string>(type: "TEXT", maxLength: 255, nullable: false),
+                DestinationFolder = table.Column<string>(type: "TEXT", maxLength: 255, nullable: false),
+                MediaType = table.Column<string>(type: "TEXT", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_FolderDbMappings", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_FolderDbMappings_PlexDbOptions_LinkedPlexOptionsId",
+                    column: x => x.LinkedPlexOptionsId,
+                    principalTable: "PlexDbOptions",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_FolderDbMappings_LinkedPlexOptionsId",
+            table: "FolderDbMappings",
+            column: "LinkedPlexOptionsId");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "FolderDbMappings");
+
+        migrationBuilder.DropTable(
+            name: "MediaDetectionDbOptions");
+
+        migrationBuilder.DropTable(
+            name: "TmDbDbOptions");
+
+        migrationBuilder.DropTable(
+            name: "PlexDbOptions");
+    }
+}

--- a/src/PlexLocalScan.Shared/Options/MediaDetectionOptions.cs
+++ b/src/PlexLocalScan.Shared/Options/MediaDetectionOptions.cs
@@ -5,5 +5,5 @@ public class MediaDetectionOptions
     public string MoviePattern { get; set; } = @"^(?<title>.+?)[\. \[]?(?<year>\d{4}).*\.(mkv|mp4|avi)$";
     public string TvShowPattern { get; set; } = @"^(?<title>.+?)[\. \[]?[Ss](?<season>\d{1,2})[\. \[]?[eE](?<episode>\d{1,2})?[-]?(?:[-eE](?<episode2>\d{1,2}))?.*\.(mkv|mp4|avi)$";
     public string TitleCleanupPattern { get; set; } = @"^(?<title>.+?)(?:\s\(?(?<year>\d{4})\)?)?\s?[-\s]*$";
-    public TimeSpan CacheDuration { get; set; } = TimeSpan.FromHours(24);
+    public TimeSpan CacheDurationSeconds { get; set; } = TimeSpan.FromSeconds(86400);
 }

--- a/src/PlexLocalScan.Shared/Options/PlexOptions.cs
+++ b/src/PlexLocalScan.Shared/Options/PlexOptions.cs
@@ -4,11 +4,11 @@ namespace PlexLocalScan.Shared.Options;
 
 public class PlexOptions
 {
-    public string Host { get; init; } = string.Empty;
-    public int Port { get; init; }
-    public string PlexToken { get; init; } = string.Empty;
-    public Collection<FolderMappingOptions> FolderMappings { get; } = [];
-    public int PollingInterval { get; init; } = 30;
-    public int ProcessNewFolderDelay { get; init; }
+    public string Host { get; set; } = string.Empty;
+    public int Port { get; set; }
+    public string PlexToken { get; set; } = string.Empty;
+    public ICollection<FolderMappingOptions> FolderMappings { get; } = [];
+    public int PollingInterval { get; set; } = 30;
+    public int ProcessNewFolderDelay { get; set; }
     public string ApiEndpoint => $"http://{Host}:{Port}";
 }

--- a/src/PlexLocalScan.Shared/Services/MovieDetectionService.cs
+++ b/src/PlexLocalScan.Shared/Services/MovieDetectionService.cs
@@ -72,7 +72,7 @@ public class MovieDetectionService : IMovieDetectionService
                 return null;
             }
 
-            _cache.Set(cacheKey, mediaInfo, _options.CacheDuration);
+            _cache.Set(cacheKey, mediaInfo, _options.CacheDurationSeconds);
             await _fileTrackingService.UpdateStatusAsync(filePath, null, mediaInfo, FileStatus.Processing);
             return mediaInfo;
         }
@@ -154,7 +154,7 @@ public class MovieDetectionService : IMovieDetectionService
                 MediaType = MediaType.Movies
             };
 
-            _cache.Set(cacheKey, mediaInfo, _options.CacheDuration);
+            _cache.Set(cacheKey, mediaInfo, _options.CacheDurationSeconds);
             return mediaInfo;
         }
         catch (Exception ex)

--- a/src/PlexLocalScan.Shared/Services/TvShowDetectionService.cs
+++ b/src/PlexLocalScan.Shared/Services/TvShowDetectionService.cs
@@ -98,7 +98,7 @@ public class TvShowDetectionService(
                 Genres = tvShowDetails.Genres?.Select(g => g.Name).ToList().AsReadOnly()
             };
             await contextService.UpdateStatusAsync(filePath, null, mediaInfo, FileStatus.Processing);
-            cache.Set(cacheKey, mediaInfo, _options.CacheDuration);
+            cache.Set(cacheKey, mediaInfo, _options.CacheDurationSeconds);
             return mediaInfo;
         }
         catch (Exception ex)
@@ -162,7 +162,7 @@ public class TvShowDetectionService(
                 Genres = tvShowDetails.Genres?.Select(g => g.Name).ToList().AsReadOnly()
             };
 
-            cache.Set(cacheKey, mediaInfo, _options.CacheDuration);
+            cache.Set(cacheKey, mediaInfo, _options.CacheDurationSeconds);
             return mediaInfo;
         }
         catch (Exception ex)


### PR DESCRIPTION
- Added new configuration options for Plex, TMDb, and Media Detection, allowing for asynchronous loading from the database.
- Updated `MediaDetectionOptions` to change `CacheDuration` to `CacheDurationSeconds` for consistency.
- Refactored `MovieDetectionService` and `TvShowDetectionService` to utilize the new `CacheDurationSeconds` property for caching media information.
- Improved the overall configuration management for the PlexLocalScan application, ensuring better flexibility and maintainability.