### PR TITLE
ci: Optimize GitHub Actions publish workflow for standalone deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,12 +30,21 @@ jobs:
       - name: Build
         run: pnpm build
         
+      - name: Copy static files
+        run: cp -r .next/static .next/standalone/
+
+      - name: Copy public files
+        run: cp -r public .next/standalone/
+
+      - name: Delete node_modules
+        run: rm -rf .next/standalone/node_modules
+
       - name: Create frontend artifact
         uses: actions/upload-artifact@v4
         with:
           name: mediaflick-frontend
-          path: mediaflick/.next
-          
+          path: mediaflick/.next/standalone
+
   publish-backend:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
- Copy static and public files to standalone directory
- Remove node_modules from standalone artifact
- Update artifact path to use standalone build