### PR TITLE
Fix Traefik API routing for internal container communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,18 +157,6 @@ services:
     labels:
       com.github.saltbox.saltbox_managed: true
       traefik.enable: true
-      traefik.http.routers.mediaflick-api-http.entrypoints: web
-      traefik.http.routers.mediaflick-api-http.middlewares: globalHeaders@file,redirect-to-https@docker,robotHeaders@file,cloudflarewarp@docker
-      traefik.http.routers.mediaflick-api-http.priority: 99
-      traefik.http.routers.mediaflick-api-http.rule: Host(`mediaflick.yourdomain.com`) && (PathPrefix(`/api`) || PathPrefix(`/ping`))
-      traefik.http.routers.mediaflick-api-http.service: mediaflick
-      traefik.http.routers.mediaflick-api.entrypoints: websecure
-      traefik.http.routers.mediaflick-api.middlewares: globalHeaders@file,secureHeaders@file,robotHeaders@file,cloudflarewarp@docker
-      traefik.http.routers.mediaflick-api.priority: 99
-      traefik.http.routers.mediaflick-api.rule: Host(`mediaflick.yourdomain.com`) && (PathPrefix(`/api`) || PathPrefix(`/ping`))
-      traefik.http.routers.mediaflick-api.service: mediaflick
-      traefik.http.routers.mediaflick-api.tls.certresolver: cfdns
-      traefik.http.routers.mediaflick-api.tls.options: securetls@file
       traefik.http.routers.mediaflick-http.entrypoints: web
       traefik.http.routers.mediaflick-http.middlewares: globalHeaders@file,redirect-to-https@docker,robotHeaders@file,cloudflarewarp@docker,authelia@docker
       traefik.http.routers.mediaflick-http.rule: Host(`mediaflick.yourdomain.com`)

--- a/mediaflick/src/lib/api/client.ts
+++ b/mediaflick/src/lib/api/client.ts
@@ -1,5 +1,5 @@
 // Base API client setup
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://mediaflick:5000/api'
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api'
 
 export class ApiError extends Error {
     constructor(

--- a/mediaflick/src/lib/api/signalr.ts
+++ b/mediaflick/src/lib/api/signalr.ts
@@ -1,7 +1,7 @@
 import { HubConnectionBuilder, HubConnection } from '@microsoft/signalr'
 import { ScannedFile, MediaType, MediaStatus } from '../api/types'
 
-const SIGNALR_BASE = process.env.NEXT_PUBLIC_SIGNALR_URL || 'http://mediaflick:5000/hubs'
+const SIGNALR_BASE = process.env.NEXT_PUBLIC_SIGNALR_URL || 'http://localhost:5000/hubs'
 
 interface ScannedFileDto {
     id: number


### PR DESCRIPTION
## Summary
- Remove complex Traefik API routing that was causing frontend connection issues
- Update frontend API client to use localhost:5000 for same-container communication  
- Simplify Traefik configuration to only route frontend web interface with Authelia protection
- Keep API completely internal and secure

## Problem
The frontend was unable to connect to the backend API, showing "Unable to connect to the API server at http://mediaflick:5000/api" errors. This was caused by conflicting Traefik routing configurations and incorrect internal networking assumptions.

## Solution
Since both frontend and backend run in the same container, simplified the approach:
1. Removed all Traefik API routing (no external API access needed)
2. Updated API client to use `localhost:5000` for internal communication
3. Only expose frontend through Traefik with proper Authelia authentication
4. Keep API completely internal and secure

## Test plan
- [ ] Deploy updated configuration
- [ ] Verify frontend can connect to backend API internally
- [ ] Verify web interface accessible through Traefik domain with Authelia
- [ ] Verify API endpoints are not accessible externally
- [ ] Test SignalR real-time connections work properly

🤖 Generated with [Claude Code](https://claude.ai/code)