### PR TITLE
Add Saltbox separated container support with runtime configuration [skip ci]

### DIFF
--- a/mediaflick/src/app/api/config/route.ts
+++ b/mediaflick/src/app/api/config/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+
+export interface RuntimeConfig {
+  apiUrl: string
+  signalrUrl: string
+}
+
+export async function GET() {
+  try {
+    const config: RuntimeConfig = {
+      apiUrl: process.env.API_URL || 'http://localhost:5000/api',
+      signalrUrl: process.env.SIGNALR_URL || 'http://localhost:5000/hubs'
+    }
+
+    return NextResponse.json(config)
+  } catch (error) {
+    console.error('Failed to load runtime configuration:', error)
+    return NextResponse.json(
+      { error: 'Failed to load configuration' },
+      { status: 500 }
+    )
+  }
+}

--- a/mediaflick/src/lib/api/client.ts
+++ b/mediaflick/src/lib/api/client.ts
@@ -1,5 +1,8 @@
 // Base API client setup
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api'
+const FALLBACK_API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api'
+
+let runtimeApiBase: string | null = null
+let configPromise: Promise<string> | null = null
 
 export class ApiError extends Error {
     constructor(
@@ -11,9 +14,37 @@ export class ApiError extends Error {
     }
 }
 
+async function getApiBase(): Promise<string> {
+    if (runtimeApiBase) {
+        return runtimeApiBase
+    }
+
+    if (!configPromise) {
+        configPromise = fetchRuntimeApiBase()
+    }
+
+    try {
+        runtimeApiBase = await configPromise
+        return runtimeApiBase
+    } catch (error) {
+        console.warn('Failed to load runtime API config, using fallback:', error)
+        return FALLBACK_API_BASE
+    }
+}
+
+async function fetchRuntimeApiBase(): Promise<string> {
+    const response = await fetch('/api/config')
+    if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+    }
+    const config = await response.json()
+    return config.apiUrl || FALLBACK_API_BASE
+}
+
 export async function fetchApi<T>(endpoint: string, options?: RequestInit): Promise<T> {
     try {
-        const response = await fetch(`${API_BASE}${endpoint}`, {
+        const apiBase = await getApiBase()
+        const response = await fetch(`${apiBase}${endpoint}`, {
             ...options,
             headers: {
                 'Content-Type': 'application/json',
@@ -44,9 +75,10 @@ export async function fetchApi<T>(endpoint: string, options?: RequestInit): Prom
 
         // Check if it's a network error
         if (error instanceof TypeError && error.message === 'Failed to fetch') {
+            const apiBase = runtimeApiBase || FALLBACK_API_BASE
             throw new ApiError(
                 0,
-                `Unable to connect to the API server at ${API_BASE}. Please check if the server is running.`
+                `Unable to connect to the API server at ${apiBase}. Please check if the server is running.`
             )
         }
 

--- a/mediaflick/src/lib/hooks/useRuntimeConfig.ts
+++ b/mediaflick/src/lib/hooks/useRuntimeConfig.ts
@@ -1,0 +1,76 @@
+import { useState, useEffect } from 'react'
+import type { RuntimeConfig } from '../../app/api/config/route'
+
+interface UseRuntimeConfigResult {
+  config: RuntimeConfig | null
+  loading: boolean
+  error: string | null
+}
+
+const defaultConfig: RuntimeConfig = {
+  apiUrl: 'http://localhost:5000/api',
+  signalrUrl: 'http://localhost:5000/hubs'
+}
+
+let cachedConfig: RuntimeConfig | null = null
+let configPromise: Promise<RuntimeConfig> | null = null
+
+export function useRuntimeConfig(): UseRuntimeConfigResult {
+  const [config, setConfig] = useState<RuntimeConfig | null>(cachedConfig)
+  const [loading, setLoading] = useState(!cachedConfig)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (cachedConfig) {
+      setConfig(cachedConfig)
+      setLoading(false)
+      return
+    }
+
+    if (!configPromise) {
+      configPromise = fetchConfig()
+    }
+
+    configPromise
+      .then((fetchedConfig) => {
+        cachedConfig = fetchedConfig
+        setConfig(fetchedConfig)
+        setError(null)
+      })
+      .catch((err) => {
+        console.warn('Failed to load runtime config, using defaults:', err)
+        cachedConfig = defaultConfig
+        setConfig(defaultConfig)
+        setError(err.message)
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }, [])
+
+  return { config, loading, error }
+}
+
+async function fetchConfig(): Promise<RuntimeConfig> {
+  try {
+    const response = await fetch('/api/config')
+    
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+    }
+
+    const config = await response.json()
+    
+    if (!config.apiUrl || !config.signalrUrl) {
+      throw new Error('Invalid configuration response')
+    }
+
+    return config
+  } catch (error) {
+    throw new Error(
+      error instanceof Error 
+        ? `Failed to fetch runtime config: ${error.message}`
+        : 'Failed to fetch runtime config: Unknown error'
+    )
+  }
+}

--- a/src/PlexLocalScan.Api/ServiceCollection/Cors.cs
+++ b/src/PlexLocalScan.Api/ServiceCollection/Cors.cs
@@ -9,7 +9,7 @@ public static class Cors
 
     public static IServiceCollection AddCorsPolicy(this IServiceCollection services, IConfiguration configuration)
     {
-        var corsOrigins = configuration.GetValue<string>("CORS_ORIGINS")?.Split(',') ?? new[] { "http://localhost:3000" };
+        var corsOrigins = configuration.GetValue<string>("CORS_ORIGINS")?.Split(',') ?? ["http://localhost:3000"];
         
         // Get logger from service provider
         var serviceProvider = services.BuildServiceProvider();

--- a/src/PlexLocalScan.Api/ServiceCollection/Middleware.cs
+++ b/src/PlexLocalScan.Api/ServiceCollection/Middleware.cs
@@ -65,8 +65,13 @@ public static class Middleware
         app.MapApiEndpoints();
 
         app.MapOpenApi();
-        app.MapScalarApiReference(options => options.Theme = ScalarTheme.Mars);
-        app.MapGet("/", () => Results.Redirect("/scalar/v1"));
+        if (app.Environment.IsDevelopment())
+        {
+            app.MapScalarApiReference(options => options.Theme = ScalarTheme.Mars);
+            app.MapGet("/", () => Results.Redirect("/scalar/v1"));
+        } else {
+            app.MapGet("/", () => Results.Ok("PlexLocalScan API is running"));
+        }
 
         return app;
     }

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,24 @@
 #!/bin/sh
-dotnet PlexLocalScan.Api.dll & node server.js
+
+# Default to running both services if SERVICE_MODE is not set
+SERVICE_MODE=${SERVICE_MODE:-"full"}
+
+case $SERVICE_MODE in
+  "frontend")
+    echo "Starting frontend only..."
+    exec node server.js
+    ;;
+  "backend")
+    echo "Starting backend only..."
+    exec dotnet PlexLocalScan.Api.dll
+    ;;
+  "full")
+    echo "Starting both frontend and backend..."
+    dotnet PlexLocalScan.Api.dll & node server.js
+    wait
+    ;;
+  *)
+    echo "Invalid SERVICE_MODE: $SERVICE_MODE. Use 'frontend', 'backend', or 'full'"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Add support for separated frontend and backend containers in Saltbox deployments
- Implement conditional startup script supporting frontend/backend/full service modes
- Create runtime API configuration system to avoid Next.js build-time environment variable limitations
- Add separate subdomain routing (api.mediaflick.domain.com) to avoid Next.js route conflicts

## Changes
- **start.sh**: Added SERVICE_MODE environment variable support for conditional startup
- **README.md**: Added separated container Docker Compose configuration for Saltbox
- **Runtime Configuration**: Server-side /api/config endpoint for dynamic API URLs
- **API Client**: Updated to fetch configuration at runtime instead of build-time
- **SignalR Client**: Updated to use runtime configuration
- **Traefik Configuration**: Separate subdomain routing for API backend

## Test plan
- [ ] Test single container deployment (SERVICE_MODE=full)
- [ ] Test separated containers (SERVICE_MODE=frontend/backend)
- [ ] Verify runtime configuration endpoint works
- [ ] Test API calls from frontend to backend subdomain
- [ ] Verify SignalR connections work across subdomains

🤖 Generated with [Claude Code](https://claude.ai/code)